### PR TITLE
Added missing org.jetbrains:annotations dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>23.0.0</version>
+      </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.11</version>


### PR DESCRIPTION
It's not possible to compile java-gtk4 from both Eclipse & Maven CLI without org.jetbrains:annotations dependency.